### PR TITLE
ras: add flux component

### DIFF
--- a/config/prte_check_flux.m4
+++ b/config/prte_check_flux.m4
@@ -1,0 +1,80 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
+# Copyright (c) 2025-2026 Triad National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# PRTE_CHECK_FLUX(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+AC_DEFUN([PRTE_CHECK_FLUX],[
+    if test -z "$prte_check_flux_happy" ; then
+	AC_ARG_WITH([flux],
+           [AS_HELP_STRING([--with-flux],
+                           [Build flux scheduler component (default: yes)])])
+
+	if test "$with_flux" = "no" ; then
+            prte_check_flux_happy="no"
+	else
+            prte_check_flux_happy="yes"
+        fi
+
+dnl
+dnl     first check if jansson available as this is needed by flux RAS
+dnl
+dnl
+        AS_IF([test "$prte_check_flux_happy" = "yes"],
+              [PRTE_CHECK_JANSSON([ras_flux_jansson], [ras_jansson_happy="yes"], [ras_jansson_happy="no"])])
+        AS_IF([test "$ras_jansson_happy" != "yes"],
+              [prte_check_flux_happy="no"])
+
+        AS_IF([test "$prte_check_flux_happy" = "yes"],
+          [OAC_CHECK_PACKAGE([flux],
+                             [$1],
+                             [flux/core.h flux/idset.h],
+                             [flux-core flux-idset flux-hostlist],
+                             [flux_open],
+                             [prte_check_flux_happy="yes"],
+                             [prte_check_flux_happy="no"])
+              ])
+
+dnl
+dnl        placeholder in case we need to add some kind of flux PLM
+dnl
+dnl        AS_IF([test "$prte_check_flux_happy" = "yes"],
+dnl              [AC_CHECK_FUNC([execve],
+dnl                             [prte_check_flux_happy="yes"],
+dnl                             [prte_check_flux_happy="no"])])
+
+
+        PRTE_SUMMARY_ADD([Resource Managers], [flux], [], [$prte_check_flux_happy])
+    fi
+
+    AS_IF([test "$prte_check_flux_happy" = "yes"],
+         [$2],
+         [AS_IF([test ! -z "$with_flux" && test "$with_flux" != "no"],
+               [AC_MSG_ERROR([flux support requested but not found.  Aborting])])
+         $3])
+])
+

--- a/config/prte_check_jansson.m4
+++ b/config/prte_check_jansson.m4
@@ -1,0 +1,84 @@
+# -*- autoconf -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2006 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006      QLogic Corp. All rights reserved.
+# Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
+# Copyright (c) 2025-2026 Triad National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# PRTE_CHECK_FLUX(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+AC_DEFUN([PRTE_CHECK_JANSSON],[
+    PRTE_VAR_SCOPE_PUSH([prte_check_jansson_save_CPPFLAGS])
+
+    AC_ARG_WITH([jansson],
+                [AS_HELP_STRING([--with-jansson(=DIR)],
+                   [Build jansson support adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+    AC_ARG_WITH([jansson-libdir],
+            [AS_HELP_STRING([--with-jansson-libdir=DIR],
+                    [Search for Jansson libraries in DIR])])
+
+    OAC_CHECK_PACKAGE([jansson],
+                      [$1],
+                      [jansson.h],
+                      [jansson],
+                      [json_loads],
+                      [prte_check_jansson_happy="yes"],
+                      [prte_check_jansson_happy="no"])
+
+    if test "$prte_check_jansson_happy" = "yes"; then
+        AC_MSG_CHECKING([if libjansson version is 2.11 or greater])
+        prte_check_jansson_save_CPPFLAGS="${CPPFLAGS}"
+        PRTE_FLAGS_APPEND_UNIQ([CPPFLAGS], [${prte_check_jansson_CPPFLAGS}])
+        AC_COMPILE_IFELSE(
+              [AC_LANG_PROGRAM([[#include <jansson.h>]],
+              [[
+        #if JANSSON_VERSION_HEX < 0x00020b00
+        #error "jansson API version is less than 2.11"
+        #endif
+                  ]])],
+              [AC_MSG_RESULT([yes])],
+              [AC_MSG_RESULT([no])
+               prte_check_jansson_happy=no])
+    	CPPFLAGS="$prte_check_jansson_save_CPPFLAGS"
+    fi
+
+    AC_MSG_CHECKING([Jansson support available])
+    AC_MSG_RESULT([$prte_check_jansson_happy])
+
+    AS_IF([test "$prte_check_jansson_happy" = "yes"],
+         [$2],
+         [AS_IF([test ! -z "$with_jansson" && test "$with_jansson" != "no"],
+               [AC_MSG_ERROR([Jansson support requested but not found.  Aborting])])
+         $3])
+
+
+    AM_CONDITIONAL([HAVE_JANSSON], [test "$prte_check_jansson_happy" = "yes"])
+
+    PRTE_SUMMARY_ADD([External Packages], [Jansson], [], [${prte_check_jansson_happy}])
+
+    PRTE_VAR_SCOPE_POP
+])

--- a/src/mca/ras/flux/Makefile.am
+++ b/src/mca/ras/flux/Makefile.am
@@ -1,0 +1,60 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2008-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
+#                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2019      Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+# Copyright (c) 2025-2026 Triad National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+        ras_flux.h \
+        ras_flux_component.c \
+        ras_flux_module.c
+
+EXTRA_DIST = help-ras-flux.txt
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_prte_ras_flux_DSO
+component_noinst =
+component_install = prte_mca_ras_flux.la
+else
+component_noinst = libprtemca_ras_flux.la
+component_install =
+endif
+
+mcacomponentdir = $(prtelibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+prte_mca_ras_flux_la_SOURCES = $(sources)
+prte_mca_ras_flux_la_CPPFLAGS = $(ras_flux_CPPFLAGS) $(ras_flux_jansson_CPPFLAGS)
+prte_mca_ras_flux_la_LDFLAGS = -module -avoid-version $(ras_flux_LDFLAGS) $(ras_flux_jansson_LDFLAGS)
+prte_mca_ras_flux_la_LIBADD = $(ras_flux_LIBS) $(ras_flux_jansson_LIBS)\
+    $(top_builddir)/src/lib@PRTE_BINARY_PREFIX@prrte.la
+
+noinst_LTLIBRARIES = $(component_noinst)
+libprtemca_ras_flux_la_SOURCES =$(sources)
+libprtemca_ras_flux_la_CPPFLAGS = $(ras_flux_CPPFLAGS) $(ras_flux_jansson_CPPFLAGS)
+libprtemca_ras_flux_la_LDFLAGS = -module -avoid-version $(ras_flux_LDFLAGS) $(ras_flux_jansson_LDFLAGS)
+libprtemca_ras_flux_la_LIBADD = $(ras_flux_LIBS) $(ras_flux_jansson_LIBS)

--- a/src/mca/ras/flux/configure.m4
+++ b/src/mca/ras/flux/configure.m4
@@ -1,0 +1,50 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2011-2013 Los Alamos National Security, LLC.
+#                         All rights reserved.
+# Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2026      Triad National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_ras_flux_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([MCA_prte_ras_flux_CONFIG],[
+    AC_CONFIG_FILES([src/mca/ras/flux/Makefile])
+
+    PRTE_CHECK_FLUX([ras_flux], [ras_flux_good=1], [ras_flux_good=0])
+
+    # The Flux ras uses jansson so check for that
+    PRTE_CHECK_JANSSON([ras_flux_jansson], [ras_jansson_good=1], [ras_jansson_good=0])
+
+    # if check worked, set wrapper flags if so.
+    # Evaluate succeed / fail
+    AS_IF([test "$ras_flux_good" = "1" -a "$ras_jansson_good" = "1"],
+          [$1],
+          [$2])
+ 
+    # set build flags to use in makefile
+    AC_SUBST([ras_flux_CPPFLAGS])
+    AC_SUBST([ras_flux_LDFLAGS])
+    AC_SUBST([ras_flux_LIBS])
+
+    AC_SUBST([ras_flux_jansson_CPPFLAGS])
+    AC_SUBST([ras_flux_jansson_LDFLAGS])
+    AC_SUBST([ras_flux_jansson_LIBS])
+])dnl

--- a/src/mca/ras/flux/help-ras-flux.txt
+++ b/src/mca/ras/flux/help-ras-flux.txt
@@ -1,0 +1,42 @@
+# -*- text -*-
+#
+# Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2024-2025 Nanook Consulting  All rights reserved.
+# Copyright (c) 2026      Triad National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English help file for PRTE MCA error messages.
+#
+[flux-broker-not-found]
+flux_open returned with an error.  This usually means no Flux broker was found.  
+
+    %s
+
+#
+[flux-kvs-lookup-failure]
+flux_kvs_lookup returned with an error. Unable to lookup resource.R info.
+
+    %s
+
+#
+[flux-kvs-lookup-get-failure]
+flux_kvs_lookup_get returned with an error. Unable to lookup resource.R info.
+
+    %s
+

--- a/src/mca/ras/flux/owner.txt
+++ b/src/mca/ras/flux/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: active

--- a/src/mca/ras/flux/ras_flux.h
+++ b/src/mca/ras/flux/ras_flux.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2025-2026 Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/**
+ * @file
+ *
+ * Resource Allocation (Flux)
+ */
+#ifndef PRTE_RAS_FLUX_H
+#define PRTE_RAS_FLUX_H
+
+#include "prte_config.h"
+#include "src/mca/ras/base/base.h"
+#include "src/mca/ras/ras.h"
+
+BEGIN_C_DECLS
+
+struct prte_mca_ras_flux_component_t {
+    prte_ras_base_component_t super;
+    char *flux_broker_uri;
+    int flux_open_flags;
+};
+typedef struct prte_mca_ras_flux_component_t prte_mca_ras_flux_component_t;
+
+PRTE_EXPORT extern prte_mca_ras_flux_component_t prte_mca_ras_flux_component;
+PRTE_EXPORT extern prte_ras_base_module_t prte_ras_flux_module;
+
+int prte_ras_flux_process_hostlist(const char *hostlist, char **array_of_hosts, int *num_hosts);
+int prte_ras_flux_hostlist_count(const char *hostlist, int *num_hosts);
+ssize_t prte_ras_flux_idset_count(const char *s);
+
+END_C_DECLS
+
+#endif

--- a/src/mca/ras/flux/ras_flux_component.c
+++ b/src/mca/ras/flux/ras_flux_component.c
@@ -1,0 +1,121 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2025-2026 Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <flux/core.h>
+#include "prte_config.h"
+#include "constants.h"
+
+#include "src/mca/base/pmix_base.h"
+#include "src/mca/base/pmix_mca_base_var.h"
+
+#include "src/mca/errmgr/errmgr.h"
+#include "src/runtime/prte_globals.h"
+#include "src/util/name_fns.h"
+
+#include "ras_flux.h"
+#include "src/mca/ras/base/base.h"
+
+/*
+ * Local variables
+ */
+static int param_priority;
+
+/*
+ * Local functions
+ */
+static int ras_flux_register(void);
+static int ras_flux_open(void);
+static int prte_mca_ras_flux_component_query(pmix_mca_base_module_t **module, int *priority);
+
+prte_mca_ras_flux_component_t prte_mca_ras_flux_component = {
+    .super = {
+        PRTE_RAS_BASE_VERSION_2_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "flux",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PRTE_MAJOR_VERSION,
+                                   PRTE_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_open_component = ras_flux_open,
+        .pmix_mca_query_component = prte_mca_ras_flux_component_query,
+        .pmix_mca_register_component_params = ras_flux_register,
+    }
+};
+PMIX_MCA_BASE_COMPONENT_INIT(prte, ras, flux)
+
+static int ras_flux_register(void)
+{
+    pmix_mca_base_component_t *c = &prte_mca_ras_flux_component.super;
+
+    param_priority = 100;
+    (void) pmix_mca_base_component_var_register(c, "priority", "Priority of the flux ras component",
+                                                PMIX_MCA_BASE_VAR_TYPE_INT, &param_priority);
+
+    prte_mca_ras_flux_component.flux_broker_uri = NULL;
+    (void) pmix_mca_base_component_var_register(c, "broker_uri", "Flux broker URI to use",
+                                                PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                                &prte_mca_ras_flux_component.flux_broker_uri);
+
+    prte_mca_ras_flux_component.flux_open_flags = 0;
+    (void) pmix_mca_base_component_var_register(c, "open_flags", "Flux open flags",
+                                                PMIX_MCA_BASE_VAR_TYPE_INT, 
+                                                &prte_mca_ras_flux_component.flux_open_flags);
+    return PRTE_SUCCESS;
+}
+
+static int ras_flux_open(void)
+{
+    return PRTE_SUCCESS;
+}
+
+static int prte_mca_ras_flux_component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    flux_t *h = NULL;
+    flux_error_t error;
+
+    /* See if we can contact a Flux broker */
+    h = flux_open_ex(prte_mca_ras_flux_component.flux_broker_uri, 
+                     prte_mca_ras_flux_component.flux_open_flags, 
+                     &error);
+    if (NULL != h) {
+        *priority = param_priority;
+        *module = (pmix_mca_base_module_t *) &prte_ras_flux_module;
+        flux_close(h);
+
+        PMIX_OUTPUT_VERBOSE((2, prte_ras_base_framework.framework_output,
+                             "%s ras:flux: available for selection",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+        return PRTE_SUCCESS;
+    }
+    /* Sadly, no */
+    *module = NULL;
+    return PRTE_ERROR;
+}

--- a/src/mca/ras/flux/ras_flux_module.c
+++ b/src/mca/ras/flux/ras_flux_module.c
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2025-2026 Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "prte_config.h"
+#include "constants.h"
+#include "types.h"
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <flux/core.h>
+#include <flux/hostlist.h>
+#include <flux/idset.h>
+#include <jansson.h>
+#include <stdio.h>
+
+#include "src/util/pmix_net.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_os_path.h"
+#include "src/util/pmix_show_help.h"
+
+#include "src/mca/errmgr/errmgr.h"
+#include "src/runtime/prte_globals.h"
+#include "src/util/name_fns.h"
+
+#include "ras_flux.h"
+#include "src/mca/ras/base/base.h"
+
+/*
+ * Local functions
+ */
+static int init(void);
+static int allocate(prte_job_t *jdata, pmix_list_t *nodes);
+static int finalize(void);
+static void modify(prte_pmix_server_req_t *req);
+static void deallocate(prte_job_t *jdata, prte_app_context_t *app);
+static struct hostlist *hostlist_from_R_nodelist (json_t *nodelist);
+static struct R_hostinfo *hostinfo_array_create (struct hostlist *hl);
+static void hostinfo_array_destroy (struct R_hostinfo *hostinfo, int n);
+static int hostinfo_append_ranks (struct R_hostinfo *hostinfo, int nnodes,
+                                  int start, const char *rankstr,
+                                  const char *corestr, char **error_str);
+static int parse_json_payload(json_t *root,  pmix_list_t *prte_nodelist);
+
+/*
+ * Global variable
+ */
+prte_ras_base_module_t prte_ras_flux_module = {
+    .init = init,
+    .allocate = allocate,
+    .deallocate = deallocate,
+    .modify = modify,
+    .finalize = finalize
+};
+
+/*
+ * helper structs
+ */
+
+struct R_hostinfo {
+    char *hostname;
+    int broker_rank;
+    int nslots;
+};
+
+static struct hostlist *hostlist_from_R_nodelist (json_t *nodelist)
+{   
+    size_t i;
+    json_t *val;
+    struct hostlist *hl = NULL;
+
+    if (!(hl = hostlist_create ())) {
+        return NULL;
+    }
+    json_array_foreach (nodelist, i, val) {
+        const char *host = json_string_value (val);
+        if (!host)
+            goto error;
+        if (hostlist_append (hl, host) < 0) {
+            goto error;
+        }
+    }
+    return hl;
+error:
+    hostlist_destroy (hl);
+    return NULL;
+}
+
+static struct R_hostinfo *hostinfo_array_create (struct hostlist *hl)
+{   
+    int i;
+    int n;
+    const char *host;
+    struct R_hostinfo *hostinfo;
+        
+    n = hostlist_count (hl);
+    if (!(hostinfo = calloc (n, sizeof (struct R_hostinfo))))
+        return NULL;     
+                          
+    i = 0;  
+    host = hostlist_first (hl);
+    while (host) {
+        if (!(hostinfo[i++].hostname = strdup (host)))
+            goto error;                  
+        host = hostlist_next (hl);       
+    }                                    
+    return hostinfo;                     
+error:                                   
+    hostinfo_array_destroy (hostinfo, n);
+    return NULL; 
+}  
+
+static void hostinfo_array_destroy (struct R_hostinfo *hostinfo, int n)
+{
+    if (hostinfo) {
+        for (int i = 0; i < n; i++)
+            free (hostinfo[i].hostname);
+        free (hostinfo);
+    }
+}
+
+static int hostinfo_append_ranks (struct R_hostinfo *hostinfo,
+                                  int nnodes,
+                                  int start,
+                                  const char *rankstr,
+                                  const char *corestr,
+                                  char **error_str)
+{                        
+    unsigned int i;       
+    struct idset *ranks = NULL;
+    struct idset *cores = NULL;
+    int ncores;
+    int count = 0;
+                                         
+    if (!(ranks = idset_decode (rankstr))
+        || !(cores = idset_decode (corestr))) {
+        *error_str = strdup("failed to decode ranks/core idset");
+        goto out;                        
+    }       
+        
+    if (idset_count (ranks) <= 0
+        || (ncores = idset_count (cores)) <= 0) {
+        *error_str = strdup("invalid rank or core count in Rv1");
+        goto out;
+    }
+    
+    i = idset_first (ranks);
+    while (i != IDSET_INVALID_ID) {
+        if (start + count > nnodes - 1) {
+            *error_str = strdup("Rlite ranks exceeds nodelist entries");
+            goto out;
+        }
+        hostinfo[start + count].broker_rank = i;
+        hostinfo[start + count].nslots = ncores;
+        count++;
+        i = idset_next (ranks, i);
+    }
+out:
+    idset_destroy (ranks);
+    idset_destroy (cores);
+    return count;
+}
+
+static int parse_json_payload(json_t *root,  pmix_list_t *prte_nodelist)
+{
+    int i, version, start, nnodes, ret = PRTE_SUCCESS;
+    char *error_str = NULL;
+    json_t *entry = NULL;
+    json_t *R_lite = NULL;
+    json_t *nodelist = NULL;
+    json_t *scheduling = NULL;
+    json_t *properties = NULL;
+    struct hostlist *hl = NULL;
+    struct R_hostinfo *hostinfo = NULL;
+    json_error_t error;
+
+    /*
+     * unpack the json
+    */
+    if (json_unpack_ex (root, &error, 0,
+                        "{s:i s?O s:{s:o s:o s?o}}",
+                        "version", &version,
+                        "scheduling", &scheduling,
+                        "execution",
+                          "R_lite", &R_lite,
+                          "nodelist", &nodelist,
+                          "properties", &properties) < 0) {
+
+        error_str = "error unpacking R object";
+        ret = PRTE_ERR_NOT_AVAILABLE;
+        goto err;
+    }
+
+    /*
+     * we only know how to parse versions 1 of resource.R
+     */
+    if (version != 1) {
+        PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
+                             "%s ras:flux:allocate: unexpected resource.R version %d expected 1",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), version));
+        ret = PRTE_ERR_NOT_AVAILABLE;
+        goto err;
+    }
+
+    if (NULL == nodelist) {
+        error_str = "'nodelist' is missing";
+        ret = PRTE_ERR_NOT_AVAILABLE;
+        goto err;
+    }
+
+    if (NULL == R_lite) {
+        error_str = "R_lite is missing";
+        ret = PRTE_ERR_NOT_AVAILABLE;
+        goto err;
+    }
+
+
+
+    hl = hostlist_from_R_nodelist (nodelist);
+    if (NULL == hl) {
+        error_str = "unable to generate hostlist from R nodelist";
+        ret = PRTE_ERR_NOT_AVAILABLE;
+        goto err;
+    }
+
+    nnodes = hostlist_count (hl);
+    if (!(hostinfo = hostinfo_array_create (hl))) {
+        error_str = "unable to generate hostinfo from hostlist";
+        ret = PRTE_ERR_NOT_AVAILABLE;
+        goto err;
+    }
+ 
+    start = 0;
+    json_array_foreach (R_lite, i, entry) {
+        const char *ranks;
+        const char *cores;
+        int rc;
+        if (json_unpack (entry,
+                         "{s:s s:{s:s}}",
+                         "rank", &ranks,
+                         "children",
+                          "core", &cores) < 0) {
+            error_str = "failed to unpack R_lite entry";
+            ret = PRTE_ERR_NOT_AVAILABLE;
+            goto err;
+        }
+        if ((rc = hostinfo_append_ranks (hostinfo,
+                                         nnodes,
+                                         start,
+                                         ranks,
+                                         cores,
+                                         &error_str)) <= 0)
+            goto err;
+        start += rc;
+    }
+
+    for(i = 0; i < nnodes; i++) {
+        prte_node_t *node;
+
+        node = PMIX_NEW(prte_node_t);
+        if (NULL == node) {
+            ret = PRTE_ERR_OUT_OF_RESOURCE;
+            goto err;
+        }
+        node->name = strdup(hostinfo[i].hostname);
+        assert(NULL != node->name);
+        node->state = PRTE_NODE_STATE_UP;
+        node->slots_inuse = 0;
+        node->slots_max = 0;
+        node->slots = hostinfo[i].nslots;
+        PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
+                             "%s ras:flux:allocate:discover: adding node %s (%d slots)",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name, hostinfo[i].nslots));
+        pmix_list_append(prte_nodelist, &node->super);
+    }
+
+err:
+    if (PRTE_SUCCESS != ret) {
+        if (NULL != error_str) {
+            PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
+                                 "%s ras:flux:allocate: %s",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), error_str));
+        } else {
+            PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
+                                 "%s ras:flux:allocate: some error happened parsing R data ret = %d",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), ret));
+       }
+    }
+
+    if(NULL != hostinfo) {
+        hostinfo_array_destroy(hostinfo, nnodes);
+    }
+    if(NULL != hl) {
+        hostlist_destroy(hl);
+    }
+    return ret;
+}
+
+/* init the module */
+static int init(void)
+{
+    return PRTE_SUCCESS;
+}
+
+/**
+ * Discover available (pre-allocated) nodes and report
+ * them back to the caller.
+ *
+ */
+static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
+{
+    int ret = PRTE_SUCCESS;
+    flux_t *h = NULL;
+    flux_future_t *f = NULL;
+    flux_error_t flux_error;
+    json_error_t json_err;
+    char *return_str=NULL;
+    const char *flux_job_id=NULL;
+
+    if ((jdata == NULL) || (nodes == NULL)) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    h = flux_open_ex(NULL, 0, &flux_error);
+    if(NULL == h) {
+        pmix_show_help("help-ras-flux.txt", "flux-broker-not-found", 1, flux_error.text);
+        ret = PRTE_ERR_NOT_FOUND;
+        goto err;
+    }
+
+    /*
+     * first get job id attribute from local broker 
+     */
+
+    flux_job_id = flux_attr_get (h, "jobid");
+    if (NULL == flux_job_id) {
+        ret = PRTE_ERR_NOT_FOUND;
+        goto err;
+    }
+
+    PMIX_OUTPUT_VERBOSE((10, prte_ras_base_framework.framework_output,
+                         "%s ras:flux:allocate: flux job id is %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), flux_job_id));
+
+    /*
+     * not sure what good this does but here goes
+     */
+    prte_job_ident = strdup(flux_job_id);
+
+    /*
+     * Lookup the "resource.R" KVS key
+     * see https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_20.html
+     * The cores data from the R is used to determine slots on each node.
+     */
+
+    f = flux_kvs_lookup(h, NULL, 0, "resource.R");
+    if (NULL == f) {
+        int errno_l = errno;
+        pmix_show_help("help-ras-flux.txt", "flux-kvs-lookup-failure", 1, strerror(errno_l));
+        ret = PRTE_ERR_NOT_FOUND;
+        goto err;
+    }
+
+    if(flux_kvs_lookup_get (f, (const char **)&return_str) < 0){
+        int errno_l = errno;
+        pmix_show_help("help-ras-flux.txt", "flux-kvs-lookup-get-failure", 1, strerror(errno_l));
+        return PRTE_ERR_NOT_FOUND;
+        goto err;
+    }
+
+    PMIX_OUTPUT_VERBOSE((10, prte_ras_base_framework.framework_output,
+                         "%s ras:flux:allocate: flux_kvs_lookup_get returned %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),return_str));
+
+    /*
+     *  Parse the returned JSON payload
+     */
+    json_t *root = json_loads(return_str, JSON_DECODE_ANY, &json_err);
+    if (NULL == root) {
+        pmix_show_help("help-ras-flux.txt", "flux-json-parse-failure", 1, json_err.text);
+        ret = PRTE_ERR_UNPACK_FAILURE;
+        goto err;
+    }
+
+    ret = parse_json_payload(root, nodes);
+
+err:
+    if (NULL != root) {
+        json_decref(root);
+    }
+    if (NULL != f) {
+        flux_future_destroy(f);
+        f = NULL;
+    }
+    if (NULL != h) {
+        flux_close(h);
+        h = NULL;
+    }
+
+    return ret;
+}
+
+/*
+ * This method is not currently available using Flux
+ */
+static void deallocate(prte_job_t *jdata, prte_app_context_t *app)
+{
+    PRTE_HIDE_UNUSED_PARAMS(jdata, app);
+    PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
+                         "%s ras:flux:deallocate: not implemented",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+}
+
+/*
+ * This method is not currently available using Flux
+ */
+static void modify(prte_pmix_server_req_t *req)
+{
+    PRTE_HIDE_UNUSED_PARAMS(req);
+    PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
+                         "%s ras:flux:modify: not implemented",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+}
+
+
+/*
+ * There's really nothing to do here
+ */
+static int finalize(void)
+{
+    PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
+                         "%s ras:flux:finalize: success (nothing to do)",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+    return PRTE_SUCCESS;
+}


### PR DESCRIPTION
This component enables prte/prterun to be used in a flux environment without need for explicit hostfiles, amongst other things.

Tested using the ssh PLM.